### PR TITLE
Solovision Tracking Support and save_tracks Feature Addition

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -185,6 +185,7 @@ CFG_BOOL_KEYS = {  # boolean-only arguments
     "nms",
     "profile",
     "multi_scale",
+    "ext_Track",
 }
 
 

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -151,6 +151,7 @@ CFG_INT_KEYS = {  # integer-only arguments
 }
 CFG_BOOL_KEYS = {  # boolean-only arguments
     "save",
+    "save_tracks"
     "exist_ok",
     "verbose",
     "deterministic",

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -126,3 +126,4 @@ cfg: # (str, optional) for overriding defaults.yaml
 
 # Tracker settings ------------------------------------------------------------------------------------------------------
 tracker: bytetrack.yaml # (str) tracker type, choices=[bytetrack.yaml]
+ext_track: False # (bool) For using external tracker

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -67,6 +67,7 @@ embed: # (list[int], optional) return feature vectors/embeddings from given laye
 # Visualize settings ---------------------------------------------------------------------------------------------------
 show: False # (bool) show predicted images and videos if environment allows
 save_frames: False # (bool) save predicted individual video frames
+save_tracks: False # (bool) save cropped track_ids 
 save_txt: False # (bool) save results as .txt file
 save_conf: False # (bool) save results with confidence scores
 save_crop: False # (bool) save cropped images with results

--- a/ultralytics/cfg/trackers/bytetrack.yaml
+++ b/ultralytics/cfg/trackers/bytetrack.yaml
@@ -2,11 +2,10 @@
 # Default YOLO tracker settings for ByteTrack tracker https://github.com/ifzhang/ByteTrack
 
 tracker_type: bytetrack # tracker type, ['botsort', 'bytetrack']
-track_high_thresh: 0.5 # threshold for the first association
+track_high_thresh: 0.25 # threshold for the first association
 track_low_thresh: 0.1 # threshold for the second association
-new_track_thresh: 0.3 # threshold for init new track if the detection does not match any tracks
-track_buffer: 300 # buffer to calculate the time when to remove tracks
+new_track_thresh: 0.25 # threshold for init new track if the detection does not match any tracks
+track_buffer: 30 # buffer to calculate the time when to remove tracks
 match_thresh: 0.8 # threshold for matching tracks
 fuse_score: True # Whether to fuse confidence scores with the iou distances before matching
-min_hits: 6 # Number of detection hits before tracking is confirmed
-min_hits_thresh: 0.7 # Number of detection hits before tracking is confirmed
+

--- a/ultralytics/engine/predictor.py
+++ b/ultralytics/engine/predictor.py
@@ -348,6 +348,8 @@ class BasePredictor:
             result.save_txt(f"{self.txt_path}.txt", save_conf=self.args.save_conf)
         if self.args.save_crop:
             result.save_crop(save_dir=self.save_dir / "crops", file_name=self.txt_path.stem)
+        if self.args.save_tracks:
+            result.save_id(save_dir=self.save_dir / "id_crops")
         if self.args.show:
             self.show(str(p))
         if self.args.save:

--- a/ultralytics/engine/results.py
+++ b/ultralytics/engine/results.py
@@ -14,6 +14,7 @@ import torch
 
 from ultralytics.data.augment import LetterBox
 from ultralytics.utils import LOGGER, SimpleClass, ops
+from ultralytics.utils.files import increment_path
 from ultralytics.utils.checks import check_requirements
 from ultralytics.utils.plotting import Annotator, colors, save_one_box
 from ultralytics.utils.torch_utils import smart_inference_mode
@@ -626,6 +627,32 @@ class Results(SimpleClass):
             filename = f"results_{Path(self.path).name}"
         self.plot(save=True, filename=filename, *args, **kwargs)
         return filename
+
+    
+    def save_id(self, save_dir, file_prefix ="id", file_name=Path("img_.jpg")): 
+        """
+        Saves cropped detection images grouped by class and tracking ID.
+        """
+        if self.probs is not None:
+            LOGGER.warning("WARNING ⚠️ Classify task do not support `save_crop_by_id`.")
+            return
+        if self.obb is not None:
+            LOGGER.warning("WARNING ⚠️ OBB task do not support `save_crop_by_id`.")
+            return
+
+        for d in self.boxes:
+            class_name = self.names[int(d.cls)]
+            object_id = f"{file_prefix}_{int(d.id)}"
+
+            # Generate the directory path
+            class_dir = Path(save_dir) / class_name / object_id
+            class_dir.mkdir(parents=True, exist_ok=True)
+            save_one_box(
+                d.xyxy,
+                self.orig_img.copy(),
+                file=class_dir / file_name,
+                BGR=True,
+            )
 
     def verbose(self):
         """

--- a/ultralytics/trackers/track.py
+++ b/ultralytics/trackers/track.py
@@ -70,10 +70,9 @@ def on_predict_postprocess_end(predictor: object, persist: bool = False) -> None
         tracker = predictor.trackers[i if is_stream else 0]
         vid_path = predictor.save_dir / Path(path[i]).name
         if not persist and predictor.vid_path[i if is_stream else 0] != vid_path:
-            tracker.reset()
             predictor.vid_path[i if is_stream else 0] = vid_path
 
-        det = (predictor.results[i].obb if is_obb else predictor.results[i].boxes).cpu().numpy()
+        det = (predictor.results[i].obb if is_obb else predictor.results[i].boxes.data).cpu().numpy()
         if len(det) == 0:
             continue
         tracks = tracker.update(det, im0s[i])

--- a/ultralytics/trackers/track.py
+++ b/ultralytics/trackers/track.py
@@ -70,9 +70,14 @@ def on_predict_postprocess_end(predictor: object, persist: bool = False) -> None
         tracker = predictor.trackers[i if is_stream else 0]
         vid_path = predictor.save_dir / Path(path[i]).name
         if not persist and predictor.vid_path[i if is_stream else 0] != vid_path:
+            if not predictor.args.ext_track:
+                tracker.reset()
             predictor.vid_path[i if is_stream else 0] = vid_path
 
-        det = (predictor.results[i].obb if is_obb else predictor.results[i].boxes.data).cpu().numpy()
+        if not predictor.args.ext_track:
+            det = (predictor.results[i].obb if is_obb else predictor.results[i].boxes).cpu().numpy()
+        else:
+            det = (predictor.results[i].obb if is_obb else predictor.results[i].boxes.data).cpu().numpy()
         if len(det) == 0:
             continue
         tracks = tracker.update(det, im0s[i])


### PR DESCRIPTION
- Added ext_track to the default YOLO arguments to support external trackers (SoloVision).
- Introduced save_tracks to save tracked IDs as separate crops for downstream tasks.
- Adjusted tracking parameters to defaults to accommodate the external tracker configuration.
- Implemented save_id function to handle saving of tracked IDs when save_tracks is enabled.
- Reverted ByteTrack-specific changes to their default state. All these changes are now reflected in solovision
- Managed tracker_reset and tracker inputs via ext_track.